### PR TITLE
Add optimized MSE (and a few other modifications)

### DIFF
--- a/graph_pit/loss/optimized.py
+++ b/graph_pit/loss/optimized.py
@@ -218,7 +218,7 @@ class OptimizedGraphPITMSELoss(OptimizedGraphPITLoss):
                 self.targets, self.segment_boundaries
         )):
             v.append(torch.sum(
-                self.estimate[:, start:stop, ...] * target[..., None, :, :],
+                self.estimate[:, start:stop, ...] * target[None, ...],
                 dim=tuple(range(1, len(self.estimate.shape)))
             ))
         similarity_matrix = torch.stack(v)

--- a/tests/test_graph_assignment_solver.py
+++ b/tests/test_graph_assignment_solver.py
@@ -154,9 +154,11 @@ def _test_runtime(num_targets=15, num_estimates=3):
     assert times['dfs'] < times['brute_force']
     assert times['greedy'] < times['brute_force']
     assert times['dynamic_programming'] < times['brute_force']
-    # These can fail occasionally because B&B's runtime is not deterministic
-    assert times['branch_and_bound'] < times['brute_force']
-    assert times['dynamic_programming'] < times['branch_and_bound']
+    # These can fail occasionally because B&B's runtime is not deterministic.
+    # Thus, add a small factor to make sure that things are at least not
+    # completely broken.
+    assert times['branch_and_bound'] < times['brute_force'] * 2
+    assert times['dynamic_programming'] < times['branch_and_bound'] * 2
 
 
 def test_runtime(num_targets=15, num_estimates=3, retries=3):


### PR DESCRIPTION
Adds an optimized variant of the Graph-PIT MSE loss (related to #1):

```python
import torch
from graph_pit.loss.optimized import optimized_graph_pit_mse_loss

# Create three target utterances and two estimated signals
targets = [torch.rand(100, 257), torch.rand(200, 257), torch.rand(150, 257)]   # List of target utterance signals 
segment_boundaries = [(0, 100), (150, 350), (300, 450)]     # One start and end time for each utterance 
estimate = torch.rand(2, 500, 257)

# Compute loss with the optimized loss function, here mse for example
loss = optimized_graph_pit_mse_loss(
    estimate, targets, segment_boundaries,
)
loss
```