### PR TITLE
Add support for different boundaries for graph and loss

### DIFF
--- a/graph_pit/loss/optimized.py
+++ b/graph_pit/loss/optimized.py
@@ -4,8 +4,8 @@ from typing import Union, Callable, List, Tuple
 import torch
 import numpy as np
 
+import graph_pit.assignment
 from graph_pit.loss.base import GraphPITBase, LossModule
-from graph_pit.assignment import graph_assignment_solvers
 
 __all__ = [
     'OptimizedGraphPITSourceAggregatedSDRLoss',
@@ -129,6 +129,7 @@ class OptimizedGraphPITSourceAggregatedSDRLoss(OptimizedGraphPITLoss):
 def optimized_graph_pit_source_aggregated_sdr_loss(
         estimate: torch.Tensor, targets: List[torch.Tensor],
         segment_boundaries: List[Tuple[int, int]],
+        graph_segment_boundaries: List[Tuple[int, int]] = None,
         assignment_solver: Union[Callable, str] =
         OptimizedGraphPITSourceAggregatedSDRLoss.assignment_solver
 ) -> torch.Tensor:
@@ -137,6 +138,7 @@ def optimized_graph_pit_source_aggregated_sdr_loss(
     """
     return OptimizedGraphPITSourceAggregatedSDRLoss(
         estimate, targets, segment_boundaries,
+        graph_segment_boundaries=graph_segment_boundaries,
         assignment_solver=assignment_solver
     ).loss
 
@@ -194,10 +196,12 @@ class OptimizedGraphPITSourceAggregatedSDRLossModule(
     def get_loss_object(
             self, estimate: torch.Tensor, targets: torch.Tensor,
             segment_boundaries: List[Tuple[int, int]],
+            graph_segment_boundaries: List[Tuple[int, int]] = None,
             **kwargs,
     ) -> loss_class:
         return self.loss_class(
             estimate, targets, segment_boundaries,
+            graph_segment_boundaries=graph_segment_boundaries,
             assignment_solver=self.assignment_solver,
             sdr_max=self.sdr_max,
         )
@@ -232,6 +236,7 @@ class OptimizedGraphPITMSELossModule(OptimizedGraphPITLoss):
 def optimized_graph_pit_mse_loss(
         estimate: torch.Tensor, targets: List[torch.Tensor],
         segment_boundaries: List[Tuple[int, int]],
+        graph_segment_boundaries: List[Tuple[int, int]] = None,
         assignment_solver: Union[Callable, str] =
         OptimizedGraphPITSourceAggregatedSDRLoss.assignment_solver
 ) -> torch.Tensor:
@@ -240,5 +245,6 @@ def optimized_graph_pit_mse_loss(
     """
     return OptimizedGraphPITMSELoss(
         estimate, targets, segment_boundaries,
+        graph_segment_boundaries=graph_segment_boundaries,
         assignment_solver=assignment_solver
     ).loss

--- a/tests/test_graph_pit.py
+++ b/tests/test_graph_pit.py
@@ -20,7 +20,7 @@ def test_graph_pit():
     # Compute loss
     loss = graph_pit_loss(
         estimate, targets, segment_boundaries,
-        torch.nn.functional.mse_loss
+        loss_fn=torch.nn.functional.mse_loss
     )
     np.testing.assert_allclose(float(loss), 0.26560837)
 
@@ -32,7 +32,7 @@ def test_graph_pit():
     estimate[0, 300:450] = 1
     loss = graph_pit_loss(
         estimate, targets, segment_boundaries,
-        torch.nn.functional.mse_loss
+        loss_fn=torch.nn.functional.mse_loss
     )
     np.testing.assert_allclose(float(loss), 0)
 
@@ -43,7 +43,7 @@ def test_graph_pit_exceptions():
     ):
         graph_pit_loss(
             torch.zeros(2, 100), torch.zeros(3, 100),
-            [(0, 100), (0, 100), (0, 100)], torch.nn.functional.mse_loss
+            [(0, 100), (0, 100), (0, 100)], loss_fn=torch.nn.functional.mse_loss
         )
 
     with pytest.raises(
@@ -52,14 +52,14 @@ def test_graph_pit_exceptions():
                   'segment boundaries!'
     ):
         graph_pit_loss(torch.zeros(2, 100), torch.zeros(3, 100),
-                       [(0, 100), (0, 100)], torch.nn.functional.mse_loss)
+                       [(0, 100), (0, 100)], loss_fn=torch.nn.functional.mse_loss)
 
     with pytest.raises(
             ValueError,
             match='Length mismatch between target and segment_boundaries'
     ):
         graph_pit_loss(torch.zeros(3, 100), torch.zeros(2, 100),
-                       [(0, 50), (0, 100)], torch.nn.functional.mse_loss)
+                       [(0, 50), (0, 100)], loss_fn=torch.nn.functional.mse_loss)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is useful for mixtures created from source recordings that contain leading and trailing silence.