### PR TITLE
Add Graph-PIT Binary Cross-Entropy loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,8 @@ If you use this code, please cite the papers:
   doi={}
 }
 ```
+
+- [3] The binary cross entropy loss: "Utterance-by-utterance overlap-aware neural diarization with Graph-PIT"
+```bibtex
+TOOD: Add bibtex entry when paper is published
+```

--- a/graph_pit/loss/optimized.py
+++ b/graph_pit/loss/optimized.py
@@ -51,7 +51,7 @@ class OptimizedGraphPITLoss(GraphPITBase):
 
     def __post_init__(self):
         super().__post_init__()
-        assert self.reduction in ('sum', 'mean')
+        assert self.reduction in ('sum', 'mean'), self.reduction
 
     @cached_property
     def similarity_matrix(self) -> torch.Tensor:
@@ -111,7 +111,7 @@ class OptimizedGraphPITSourceAggregatedSDRLoss(OptimizedGraphPITLoss):
     def __post_init__(self):
         super().__post_init__()
         assert self.reduction == 'sum', (
-            'Only sum reduction makes sense for SA-SDR'
+            f'Only sum reduction makes sense for SA-SDR, not {self.reduction}'
         )
 
     @cached_property

--- a/tests/test_optimized_graph_pit.py
+++ b/tests/test_optimized_graph_pit.py
@@ -1,13 +1,13 @@
 import functools
 
-from graph_pit.loss.optimized import OptimizedGraphPITSourceAggregatedSDRLoss, OptimizedGraphPITMSELoss
+from graph_pit.loss.optimized import OptimizedGraphPITSourceAggregatedSDRLoss, OptimizedGraphPITMSELoss, OptimizedGraphPITBCEWithLogitsLoss
 from graph_pit.loss.regression import sdr_loss
 from graph_pit.loss.unoptimized import GraphPITLoss
 from graph_pit.assignment import NoSolutionError
 import torch
 import pytest
 import numpy as np
-
+import torch.nn.functional
 
 @pytest.mark.parametrize(
     'seed,num_samples,num_estimates,segment_boundaries,algorithm,unoptimized_loss_fn,optimized_loss_class',
@@ -21,6 +21,7 @@ import numpy as np
      for unoptimized_loss_fn, optimized_loss_class in [
          (functools.partial(sdr_loss, aggregation='in_fraction', reduction='sum'), OptimizedGraphPITSourceAggregatedSDRLoss),
          (torch.nn.functional.mse_loss, OptimizedGraphPITMSELoss),
+         (functools.partial(torch.nn.functional.binary_cross_entropy_with_logits, reduction='sum',), OptimizedGraphPITBCEWithLogitsLoss),
      ]],
 )
 def test_optimized_graph_pit(
@@ -59,7 +60,8 @@ def test_optimized_graph_pit(
     'optimized_loss_class',
     [
          OptimizedGraphPITSourceAggregatedSDRLoss,
-         OptimizedGraphPITMSELoss
+         OptimizedGraphPITMSELoss,
+        OptimizedGraphPITBCEWithLogitsLoss,
      ],
 )
 def test_optimized_graph_pit_exceptions(
@@ -100,4 +102,3 @@ def test_optimized_graph_pit_exceptions(
             torch.zeros(2, 100), torch.zeros(2, 100),
             [(0, 100), (50, 150)],
         )
-

--- a/tests/test_optimized_graph_pit.py
+++ b/tests/test_optimized_graph_pit.py
@@ -20,8 +20,8 @@ import torch.nn.functional
      ] for algorithm in ['optimal_brute_force', 'optimal_branch_and_bound']
      for unoptimized_loss_fn, optimized_loss_class in [
          (functools.partial(sdr_loss, aggregation='in_fraction', reduction='sum'), OptimizedGraphPITSourceAggregatedSDRLoss),
-         (torch.nn.functional.mse_loss, OptimizedGraphPITMSELoss),
-         (functools.partial(torch.nn.functional.binary_cross_entropy_with_logits, reduction='sum',), OptimizedGraphPITBCEWithLogitsLoss),
+        (torch.nn.functional.mse_loss, OptimizedGraphPITMSELoss),
+         (functools.partial(torch.nn.functional.binary_cross_entropy_with_logits, ), OptimizedGraphPITBCEWithLogitsLoss),
      ]],
 )
 def test_optimized_graph_pit(


### PR DESCRIPTION
Add the Graph-PIT Binary Cross-Entropy loss used in the paper "Utterance-by-utterance overlap-aware neural diarization with Graph-PIT" which is accepted at Interspeech 2022.